### PR TITLE
Found that the dis.read() call that I removed was removing the first cha...

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka-word2vec/src/main/java/org/deeplearning4j/word2vec/loader/Word2VecLoader.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka-word2vec/src/main/java/org/deeplearning4j/word2vec/loader/Word2VecLoader.java
@@ -162,7 +162,6 @@ public class Word2VecLoader {
                 }
                 wordIndex.add(word);
                 wordVectors.putRow(i, new FloatMatrix(vectors));
-                dis.read();
             }
         } finally {
             bis.close();


### PR DESCRIPTION
...racter of the word strings. My calls to method getWordVector from class Word2Vec were therefore not returning the correct vector.
