### PR TITLE
Fix potential null pointer exception in yield()

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-scaleout-akka-word2vec/src/main/java/org/deeplearning4j/rntn/Tree.java
+++ b/deeplearning4j-scaleout/deeplearning4j-scaleout-akka-word2vec/src/main/java/org/deeplearning4j/rntn/Tree.java
@@ -86,7 +86,7 @@ public class Tree implements Serializable {
      */
     private List<String> yield(List<String> labels) {
         labels.add(label);
-        for(Tree t : children) {
+        for(Tree t : children()) {
             labels.addAll(t.yield());
         }
         return labels;


### PR DESCRIPTION
Using the method children() initializes the property children if it is null.
Using the property directly results in a null pointer exception in that case.
