### PR TITLE
Update Word2Vec.java

### DIFF
--- a/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
+++ b/deeplearning4j-scaleout/deeplearning4j-nlp/src/main/java/org/deeplearning4j/models/word2vec/Word2Vec.java
@@ -641,7 +641,7 @@ public class Word2Vec implements Persistable {
                 continue;
 
             VocabWord word2 = sentence.get(c1);
-            iterate(word);
+            iterate(word, word2);
         }
     }
 


### PR DESCRIPTION
fixed missing word2 on iterate. see https://github.com/agibsonccc/java-deeplearning/issues/65
