### PR TITLE
Add profiles to parent `pom.xml` that allow multiple platforms

### DIFF
--- a/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
+++ b/nd4j/nd4j-backends/nd4j-backend-impls/pom.xml
@@ -439,6 +439,200 @@
         <profile>
             <id>testresources</id>
         </profile>
+
+        <!-- Profiles to modify the transitive dependencies when picked up from other pom.xml files, for example:
+                 mvn -Djavacpp.platform.none -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64 ... -->
+        <profile>
+            <id>javacpp.platform.android-arm-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.android-arm</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.android-arm>android-arm</javacpp.platform.android-arm>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.android-arm64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.android-arm64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.android-arm64>android-arm64</javacpp.platform.android-arm64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.android-x86-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.android-x86</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.android-x86>android-x86</javacpp.platform.android-x86>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.android-x86_64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.android-x86_64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.android-x86_64>android-x86_64</javacpp.platform.android-x86_64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.ios-arm-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.ios-arm</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.ios-arm>ios-arm</javacpp.platform.ios-arm>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.ios-arm64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.ios-arm64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.ios-arm64>ios-arm64</javacpp.platform.ios-arm64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.ios-x86-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.ios-x86</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.ios-x86>ios-x86</javacpp.platform.ios-x86>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.ios-x86_64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.ios-x86_64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.ios-x86_64>ios-x86_64</javacpp.platform.ios-x86_64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.linux-armhf-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.linux-armhf</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.linux-armhf>linux-armhf</javacpp.platform.linux-armhf>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.linux-arm64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.linux-arm64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.linux-arm64>linux-arm64</javacpp.platform.linux-arm64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.linux-ppc64le-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.linux-ppc64le</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.linux-ppc64le>linux-ppc64le</javacpp.platform.linux-ppc64le>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.linux-x86-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.linux-x86</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.linux-x86>linux-x86</javacpp.platform.linux-x86>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.linux-x86_64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.linux-x86_64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.linux-x86_64>linux-x86_64</javacpp.platform.linux-x86_64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.macosx-x86_64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.macosx-x86_64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.macosx-x86_64>macosx-x86_64</javacpp.platform.macosx-x86_64>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.windows-x86-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.windows-x86</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.windows-x86>windows-x86</javacpp.platform.windows-x86>
+            </properties>
+        </profile>
+
+        <profile>
+            <id>javacpp.platform.windows-x86_64-true</id>
+            <activation>
+                <property>
+                    <name>javacpp.platform.windows-x86_64</name>
+                </property>
+            </activation>
+            <properties>
+                <javacpp.platform.windows-x86_64>windows-x86_64</javacpp.platform.windows-x86_64>
+            </properties>
+        </profile>
     </profiles>
 
     <reporting>

--- a/pom.xml
+++ b/pom.xml
@@ -861,7 +861,7 @@
             </properties>
         </profile>
 
-        <!-- If someone knows a better way to do this, please do let me know! -->
+        <!-- Profiles to set the default javacpp.platform property: If someone knows a better way to do this, please do let me know! -->
         <profile>
             <id>linux</id>
             <activation>


### PR DESCRIPTION
For example: `mvn -Djavacpp.platform.none -Djavacpp.platform.linux-x86_64 -Djavacpp.platform.windows-x86_64 ...`

Successfully tested manually on dl4j-examples and `mvn dependency:tree`.