### PR TITLE
Add thousand-separator commas to TotalParams

### DIFF
--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java
@@ -4265,7 +4265,7 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
                     Layer currentLayer = ((LayerVertex) currentVertex).getLayer();
                     classNameArr = currentLayer.getClass().getName().split("\\.");
                     className = classNameArr[classNameArr.length - 1];
-                    paramCount = String.valueOf(currentLayer.numParams());
+                    paramCount = String.format("%,d", currentLayer.numParams());
                     //layer with params
                     if (currentLayer.numParams() > 0) {
                         paramShape = "";
@@ -4372,9 +4372,9 @@ public class ComputationGraph implements Serializable, Model, NeuralNetwork {
         }
 
         ret.append(StringUtils.repeat("-", totalLength))
-                .append(String.format("\n%30s %d", "Total Parameters: ", params().length()))
-                .append(String.format("\n%30s %d", "Trainable Parameters: ", params().length() - frozenParams))
-                .append(String.format("\n%30s %d", "Frozen Parameters: ", frozenParams))
+                .append(String.format("\n%30s %,d", "Total Parameters: ", params().length()))
+                .append(String.format("\n%30s %,d", "Trainable Parameters: ", params().length() - frozenParams))
+                .append(String.format("\n%30s %,d", "Frozen Parameters: ", frozenParams))
                 .append("\n")
                 .append(StringUtils.repeat("=", totalLength))
                 .append("\n");

--- a/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
+++ b/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/multilayer/MultiLayerNetwork.java
@@ -3553,7 +3553,7 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
             String out = "-";
             String[] classNameArr = currentLayer.getClass().getName().split("\\.");
             String className = classNameArr[classNameArr.length - 1];
-            String paramCount = String.valueOf(currentLayer.numParams());
+            String paramCount = String.format("%,d", currentLayer.numParams());
             String inShape = "";
             String outShape = "";
             InputPreProcessor preProcessor;
@@ -3640,9 +3640,9 @@ public class MultiLayerNetwork implements Serializable, Classifier, Layer, Neura
         }
 
         ret.append(StringUtils.repeat("-", totalLength));
-        ret.append(String.format("\n%30s %d", "Total Parameters: ", params().length()));
-        ret.append(String.format("\n%30s %d", "Trainable Parameters: ", params().length() - frozenParams));
-        ret.append(String.format("\n%30s %d", "Frozen Parameters: ", frozenParams));
+        ret.append(String.format("\n%30s %,d", "Total Parameters: ", params().length()));
+        ret.append(String.format("\n%30s %,d", "Trainable Parameters: ", params().length() - frozenParams));
+        ret.append(String.format("\n%30s %,d", "Frozen Parameters: ", frozenParams));
         ret.append("\n");
         ret.append(StringUtils.repeat("=", totalLength));
         ret.append("\n");


### PR DESCRIPTION
## What changes were proposed in this pull request?

The number of parameters can be quite large, and it would help the reading of the summary printout to have the TotalParams column & values at the bottom have thousand-separator-commas in them. This PR adds that.

## How was this patch tested?

Sorry, no testing, edits are tiny and hopefully clear. Didn't run mvn formatter since all changes were inline.

Hopefully the signoff worked... 