### PR TITLE
Remove duplicate code for append() and prepend() Fix #7983

### DIFF
--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -375,8 +375,7 @@ public class Nd4j {
         INDArray concatArray = Nd4j.valueArrayOf(paShape, val, arr.dataType());
         return appendFlag ? Nd4j.concat(axis, arr, concatArray) : Nd4j.concat(axis, concatArray, arr);
     }
-
-
+    
     /**
      * Expand the array dimensions.
      * This is equivalent to

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -343,16 +343,29 @@ public class Nd4j {
 
 
     /**
-     * Append the given
-     * array with the specified value size
-     * along a particular axis
+     * @see #appendImpl(INDArray, int, double, int, boolean)
+     */
+    public static INDArray append(INDArray arr, int padAmount, double val, int axis) {
+        return appendImpl(arr, padAmount, val, axis, true);
+    }
+
+    /**
+     * @see #appendImpl(INDArray, int, double, int, boolean)
+     */
+    public static INDArray prepend(INDArray arr, int padAmount, double val, int axis) {
+        return appendImpl(arr, padAmount, val, axis, false);
+    }
+
+    /**
+     * Append / Prepend the given array with the specified value size along a particular axis
      * @param arr the array to append to
      * @param padAmount the pad amount of the array to be returned
      * @param val the value to append
      * @param axis the axis to append to
+     * @param appendFlag flag to determine Append/Prepend.
      * @return the newly created array
      */
-    public static INDArray append(INDArray arr, int padAmount, double val, int axis) {
+    private static INDArray appendImpl(INDArray arr, int padAmount, double val, int axis, boolean appendFlag){
         if (padAmount == 0)
             return arr;
         long[] paShape = ArrayUtil.copy(arr.shape());
@@ -360,30 +373,9 @@ public class Nd4j {
             axis = axis + arr.shape().length;
         paShape[axis] = padAmount;
         INDArray concatArray = Nd4j.valueArrayOf(paShape, val, arr.dataType());
-        return Nd4j.concat(axis, arr, concatArray);
+        return appendFlag ? Nd4j.concat(axis, arr, concatArray) : Nd4j.concat(axis, concatArray, arr);
     }
 
-    /**
-     * Append the given
-     * array with the specified value size
-     * along a particular axis
-     * @param arr the array to append to
-     * @param padAmount the pad amount of the array to be returned
-     * @param val the value to append
-     * @param axis the axis to append to
-     * @return the newly created array
-     */
-    public static INDArray prepend(INDArray arr, int padAmount, double val, int axis) {
-        if (padAmount == 0)
-            return arr;
-
-        long[] paShape = ArrayUtil.copy(arr.shape());
-        if (axis < 0)
-            axis = axis + arr.shape().length;
-        paShape[axis] = padAmount;
-        INDArray concatArr = Nd4j.valueArrayOf(paShape, val, arr.dataType());
-        return Nd4j.concat(axis, concatArr, arr);
-    }
 
     /**
      * Expand the array dimensions.

--- a/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
+++ b/nd4j/nd4j-backends/nd4j-api-parent/nd4j-api/src/main/java/org/nd4j/linalg/factory/Nd4j.java
@@ -343,27 +343,29 @@ public class Nd4j {
 
 
     /**
-     * @see #appendImpl(INDArray, int, double, int, boolean)
+     * Append the given array with the specified value size along a particular axis.
+     * The prepend method has the same signature and prepends the given array.
+     * @param arr the array to append to
+     * @param padAmount the pad amount of the array to be returned
+     * @param val the value to append
+     * @param axis the axis to append to
+     * @return the newly created array
      */
     public static INDArray append(INDArray arr, int padAmount, double val, int axis) {
         return appendImpl(arr, padAmount, val, axis, true);
     }
 
     /**
-     * @see #appendImpl(INDArray, int, double, int, boolean)
+     * @see #append(INDArray, int, double, int)
      */
     public static INDArray prepend(INDArray arr, int padAmount, double val, int axis) {
         return appendImpl(arr, padAmount, val, axis, false);
     }
 
     /**
-     * Append / Prepend the given array with the specified value size along a particular axis
-     * @param arr the array to append to
-     * @param padAmount the pad amount of the array to be returned
-     * @param val the value to append
-     * @param axis the axis to append to
-     * @param appendFlag flag to determine Append/Prepend.
-     * @return the newly created array
+     * Append / Prepend shared implementation.
+     * @param appendFlag flag to determine Append / Prepend.
+     * @see #append(INDArray, int, double, int)
      */
     private static INDArray appendImpl(INDArray arr, int padAmount, double val, int axis, boolean appendFlag){
         if (padAmount == 0)


### PR DESCRIPTION
## What changes were proposed in this pull request?
Duplicate code for `append()` and `prepend()` moved to a common function.

## How was this patch tested?
Unit tests for `append `and `prepend `were copied to a new JUnit project. Made sure they worked on a manual build of the old code and on beta4. Made sure the tests passed on the new code from the JUnit project and from a build of the updated code.
