### PR TITLE
Disallow creating bad classification iterator

### DIFF
--- a/deeplearning4j/deeplearning4j-data/deeplearning4j-datavec-iterators/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
+++ b/deeplearning4j/deeplearning4j-data/deeplearning4j-datavec-iterators/src/main/java/org/deeplearning4j/datasets/datavec/RecordReaderDataSetIterator.java
@@ -160,6 +160,11 @@ public class RecordReaderDataSetIterator implements DataSetIterator {
      */
     public RecordReaderDataSetIterator(RecordReader recordReader, int batchSize, int labelIndexFrom, int labelIndexTo,
                                        boolean regression) {
+        if (!regression) { 
+            throw new IllegalArgumentException("This constructor is only for creating regression iterators. " +
+                                               "If you're doing classification you need to use another constructor that " + 
+                                               "(implicitly) specifies numPossibleLabels");
+        }
         this(recordReader, new SelfWritableConverter(), batchSize, labelIndexFrom, labelIndexTo, -1, -1, regression);
     }
 


### PR DESCRIPTION
When doing classification we need to know the `numPossibleLabels`. If it's set to -1, then we get obscure and confusing null-pointers when accessing labels deep down the stack of calling `ComputationGraph.fit` on the iterator. This PR blocks the user from shooting themselves in the foot.

## Background
Ran into a weird null-pointer when calling fit on a classification network. My data looked pristine, and this was quite gnarly to track down. Turns out I had re-used some code from a segmentation task and was creating the iterator in the same way, but just passing in "false" for regression. 

This lead to `RecrodReaderMultiDataSetIterator` having an empty `outputs` => no `ComputationGraph.labels` => null pointer on line 2627 in [`ComputationGraph.calcBackpropGradients`](https://github.com/eclipse/deeplearning4j/blob/master/deeplearning4j/deeplearning4j-nn/src/main/java/org/deeplearning4j/nn/graph/ComputationGraph.java#L2627). 

Switching to another constructor solved the problem. 

## Caveat
There might be cases where calling this constructor with `regression = false` makes sense? 