### PR TITLE
RL4J Added listener pattern to SyncLearning

### DIFF
--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/Learning.java
@@ -125,8 +125,6 @@ public abstract class Learning<O extends Encodable, A, AS extends ActionSpace<A>
         return nshape;
     }
 
-    protected abstract IDataManager getDataManager();
-
     public abstract NN getNeuralNet();
 
     public int incrementStep() {

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncLearning.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/async/AsyncLearning.java
@@ -21,6 +21,7 @@ import org.deeplearning4j.rl4j.learning.Learning;
 import org.deeplearning4j.rl4j.network.NeuralNet;
 import org.deeplearning4j.rl4j.space.ActionSpace;
 import org.deeplearning4j.rl4j.space.Encodable;
+import org.deeplearning4j.rl4j.util.IDataManager;
 import org.nd4j.linalg.factory.Nd4j;
 
 /**
@@ -36,6 +37,7 @@ import org.nd4j.linalg.factory.Nd4j;
 public abstract class AsyncLearning<O extends Encodable, A, AS extends ActionSpace<A>, NN extends NeuralNet>
                 extends Learning<O, A, AS, NN> {
 
+    protected abstract IDataManager getDataManager();
 
     public AsyncLearning(AsyncConfiguration conf) {
         super(conf);

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEpochEndEvent.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEpochEndEvent.java
@@ -1,0 +1,15 @@
+package org.deeplearning4j.rl4j.learning.sync.listener;
+
+import lombok.Getter;
+import org.deeplearning4j.rl4j.learning.Learning;
+import org.deeplearning4j.rl4j.util.IDataManager;
+
+public class SyncTrainingEpochEndEvent extends SyncTrainingEvent {
+    @Getter
+    private final IDataManager.StatEntry statEntry;
+
+    public SyncTrainingEpochEndEvent(Learning learning, IDataManager.StatEntry statEntry) {
+        super(learning);
+        this.statEntry = statEntry;
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEpochEndEvent.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEpochEndEvent.java
@@ -4,7 +4,14 @@ import lombok.Getter;
 import org.deeplearning4j.rl4j.learning.Learning;
 import org.deeplearning4j.rl4j.util.IDataManager;
 
+/**
+ * A subclass of SyncTrainingEvent that is passed to SyncTrainingListener.onEpochEnd()
+ */
 public class SyncTrainingEpochEndEvent extends SyncTrainingEvent {
+
+    /**
+     * The stats of the epoch training
+     */
     @Getter
     private final IDataManager.StatEntry statEntry;
 

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEvent.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEvent.java
@@ -1,0 +1,18 @@
+package org.deeplearning4j.rl4j.learning.sync.listener;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.deeplearning4j.rl4j.learning.Learning;
+
+public class SyncTrainingEvent {
+
+    @Getter
+    private final Learning learning;
+
+    @Getter @Setter
+    private Boolean canContinue = true;
+
+    public SyncTrainingEvent(Learning learning) {
+        this.learning = learning;
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEvent.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingEvent.java
@@ -4,13 +4,16 @@ import lombok.Getter;
 import lombok.Setter;
 import org.deeplearning4j.rl4j.learning.Learning;
 
+/**
+ * SyncTrainingEvent are passed as parameters to the events of SyncTrainingListener
+ */
 public class SyncTrainingEvent {
 
+    /**
+     * The source of the event
+     */
     @Getter
     private final Learning learning;
-
-    @Getter @Setter
-    private Boolean canContinue = true;
 
     public SyncTrainingEvent(Learning learning) {
         this.learning = learning;

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingListener.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingListener.java
@@ -1,0 +1,31 @@
+package org.deeplearning4j.rl4j.learning.sync.listener;
+
+import org.deeplearning4j.rl4j.util.IDataManager;
+
+/**
+ * A listener interface to use with a descendant of {@link org.deeplearning4j.rl4j.learning.sync.SyncLearning}
+ */
+public interface SyncTrainingListener {
+    /**
+     * Called once when the training starts. The training can be aborted by calling event.setCanContinue(false)
+     * @param event
+     */
+    void onTrainingStart(SyncTrainingEvent event);
+
+    /**
+     * Called once when the training has finished. This method called even when the training has been aborted.
+     */
+    void onTrainingEnd();
+
+    /**
+     * Called before the start of every epoch. The training can be aborted by calling event.setCanContinue(false)
+     * @param event
+     */
+    void onEpochStart(SyncTrainingEvent event);
+
+    /**
+     * Called after the end of every epoch. The training can be aborted by calling event.setCanContinue(false)
+     * @param event
+     */
+    void onEpochEnd(SyncTrainingEpochEndEvent event);
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingListener.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/listener/SyncTrainingListener.java
@@ -1,31 +1,45 @@
 package org.deeplearning4j.rl4j.learning.sync.listener;
 
-import org.deeplearning4j.rl4j.util.IDataManager;
-
 /**
  * A listener interface to use with a descendant of {@link org.deeplearning4j.rl4j.learning.sync.SyncLearning}
  */
 public interface SyncTrainingListener {
-    /**
-     * Called once when the training starts. The training can be aborted by calling event.setCanContinue(false)
-     * @param event
-     */
-    void onTrainingStart(SyncTrainingEvent event);
+
+    public enum ListenerResponse {
+        /**
+         * Tell SyncLearning to continue calling the listeners and the training.
+         */
+        CONTINUE,
+
+        /**
+         * Tell SyncLearning to stop calling the listeners and terminate the training.
+         */
+        STOP,
+    }
 
     /**
-     * Called once when the training has finished. This method called even when the training has been aborted.
+     * Called once when the training starts.
+     * @param event
+     * @return A ListenerResponse telling the source of the event if it should go on or cancel the training.
+     */
+    ListenerResponse onTrainingStart(SyncTrainingEvent event);
+
+    /**
+     * Called once when the training has finished. This method is called even when the training has been aborted.
      */
     void onTrainingEnd();
 
     /**
-     * Called before the start of every epoch. The training can be aborted by calling event.setCanContinue(false)
+     * Called before the start of every epoch.
      * @param event
+     * @return A ListenerResponse telling the source of the event if it should continue or stop the training.
      */
-    void onEpochStart(SyncTrainingEvent event);
+    ListenerResponse onEpochStart(SyncTrainingEvent event);
 
     /**
-     * Called after the end of every epoch. The training can be aborted by calling event.setCanContinue(false)
+     * Called after the end of every epoch.
      * @param event
+     * @return A ListenerResponse telling the source of the event if it should continue or stop the training.
      */
-    void onEpochEnd(SyncTrainingEpochEndEvent event);
+    ListenerResponse onEpochEnd(SyncTrainingEpochEndEvent event);
 }

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -68,8 +68,10 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
     private double accuReward = 0;
 
     /**
-     * Obsolete. Use QLearningDiscrete(MDP, IDQN, QLConfiguration, int) with addListener() instead.
+     * @deprecated
+     * Use QLearningDiscrete(MDP, IDQN, QLConfiguration, int) and add the required listeners with addListener() instead.
      */
+    @Deprecated
     public QLearningDiscrete(MDP<O, Integer, DiscreteSpace> mdp, IDQN dqn, QLConfiguration conf,
                     IDataManager dataManager, int epsilonNbStep) {
         this(mdp, dqn, conf, epsilonNbStep);

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/learning/sync/qlearning/discrete/QLearningDiscrete.java
@@ -18,7 +18,6 @@ package org.deeplearning4j.rl4j.learning.sync.qlearning.discrete;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.nd4j.linalg.primitives.Pair;
 import org.deeplearning4j.gym.StepReply;
 import org.deeplearning4j.rl4j.learning.Learning;
 import org.deeplearning4j.rl4j.learning.sync.Transition;
@@ -29,12 +28,13 @@ import org.deeplearning4j.rl4j.policy.DQNPolicy;
 import org.deeplearning4j.rl4j.policy.EpsGreedy;
 import org.deeplearning4j.rl4j.space.DiscreteSpace;
 import org.deeplearning4j.rl4j.space.Encodable;
-import org.deeplearning4j.rl4j.util.Constants;
+import org.deeplearning4j.rl4j.util.DataManagerSyncTrainingListener;
 import org.deeplearning4j.rl4j.util.IDataManager;
 import org.nd4j.linalg.api.ndarray.INDArray;
 import org.nd4j.linalg.factory.Nd4j;
 import org.nd4j.linalg.indexing.INDArrayIndex;
 import org.nd4j.linalg.indexing.NDArrayIndex;
+import org.nd4j.linalg.primitives.Pair;
 import org.nd4j.linalg.util.ArrayUtil;
 
 import java.util.ArrayList;
@@ -53,8 +53,6 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
     @Getter
     final private QLConfiguration configuration;
     @Getter
-    final private IDataManager dataManager;
-    @Getter
     final private MDP<O, Integer, DiscreteSpace> mdp;
     @Getter
     final private IDQN currentDQN;
@@ -68,23 +66,28 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
     private int lastAction;
     private INDArray history[] = null;
     private double accuReward = 0;
-    private int lastMonitor = -Constants.MONITOR_FREQ;
 
-
+    /**
+     * Obsolete. Use QLearningDiscrete(MDP, IDQN, QLConfiguration, int) with addListener() instead.
+     */
     public QLearningDiscrete(MDP<O, Integer, DiscreteSpace> mdp, IDQN dqn, QLConfiguration conf,
                     IDataManager dataManager, int epsilonNbStep) {
+        this(mdp, dqn, conf, epsilonNbStep);
+        addListener(DataManagerSyncTrainingListener.builder(dataManager).build());
+    }
+
+    public QLearningDiscrete(MDP<O, Integer, DiscreteSpace> mdp, IDQN dqn, QLConfiguration conf,
+                             int epsilonNbStep) {
         super(conf);
         this.configuration = conf;
         this.mdp = mdp;
-        this.dataManager = dataManager;
         currentDQN = dqn;
         targetDQN = dqn.clone();
         policy = new DQNPolicy(getCurrentDQN());
         egPolicy = new EpsGreedy(policy, mdp, conf.getUpdateStart(), epsilonNbStep, getRandom(), conf.getMinEpsilon(),
-                        this);
+                this);
         mdp.getActionSpace().setSeed(conf.getSeed());
     }
-
 
     public void postEpoch() {
 
@@ -97,14 +100,6 @@ public abstract class QLearningDiscrete<O extends Encodable> extends QLearning<O
         history = null;
         lastAction = 0;
         accuReward = 0;
-
-        if (getStepCounter() - lastMonitor >= Constants.MONITOR_FREQ && getHistoryProcessor() != null
-                        && getDataManager().isSaveData()) {
-            lastMonitor = getStepCounter();
-            int[] shape = getMdp().getObservationSpace().getShape();
-            getHistoryProcessor().startMonitor(getDataManager().getVideoDir() + "/video-" + getEpochCounter() + "-"
-                            + getStepCounter() + ".mp4", shape);
-        }
     }
 
     /**

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/util/DataManagerSyncTrainingListener.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/util/DataManagerSyncTrainingListener.java
@@ -1,0 +1,105 @@
+package org.deeplearning4j.rl4j.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingEpochEndEvent;
+import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingEvent;
+import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingListener;
+
+@Slf4j
+public class DataManagerSyncTrainingListener implements SyncTrainingListener {
+    private final IDataManager dataManager;
+    private final int saveFrequency;
+    private final int monitorFrequency;
+
+    private int lastSave;
+    private int lastMonitor;
+
+    private DataManagerSyncTrainingListener(Builder builder) {
+        this.dataManager = builder.dataManager;
+
+        this.saveFrequency = builder.saveFrequency;
+        this.lastSave = -builder.saveFrequency;
+
+        this.monitorFrequency = builder.monitorFrequency;
+        this.lastMonitor = -builder.monitorFrequency;
+    }
+
+    @Override
+    public void onTrainingStart(SyncTrainingEvent event) {
+        try {
+            dataManager.writeInfo(event.getLearning());
+        } catch (Exception e) {
+            log.error("Training failed.", e);
+            e.printStackTrace();
+
+            event.setCanContinue(false);
+        }
+    }
+
+    @Override
+    public void onTrainingEnd() {
+        // Do nothing
+    }
+
+    @Override
+    public void onEpochStart(SyncTrainingEvent event) {
+        int stepCounter = event.getLearning().getStepCounter();
+
+        if (stepCounter - lastMonitor >= monitorFrequency
+                && event.getLearning().getHistoryProcessor() != null
+                && dataManager.isSaveData()) {
+            lastMonitor = stepCounter;
+            int[] shape = event.getLearning().getMdp().getObservationSpace().getShape();
+            event.getLearning().getHistoryProcessor().startMonitor(dataManager.getVideoDir() + "/video-" + event.getLearning().getEpochCounter() + "-"
+                    + stepCounter + ".mp4", shape);
+        }
+    }
+
+    @Override
+    public void onEpochEnd(SyncTrainingEpochEndEvent event) {
+        try {
+            int stepCounter = event.getLearning().getStepCounter();
+            if (stepCounter - lastSave >= saveFrequency) {
+                dataManager.save(event.getLearning());
+                lastSave = stepCounter;
+            }
+
+            dataManager.appendStat(event.getStatEntry());
+            dataManager.writeInfo(event.getLearning());
+        } catch (Exception e) {
+            log.error("Training failed.", e);
+            e.printStackTrace();
+
+            event.setCanContinue(false);
+        }
+    }
+
+    public static Builder builder(IDataManager dataManager) {
+        return new Builder(dataManager);
+    }
+
+    public static class Builder {
+        private final IDataManager dataManager;
+        private int saveFrequency = Constants.MODEL_SAVE_FREQ;
+        private int monitorFrequency = Constants.MONITOR_FREQ;
+
+        public Builder(IDataManager dataManager) {
+            this.dataManager = dataManager;
+        }
+
+        public Builder saveFrequency(int saveFrequency) {
+            this.saveFrequency = saveFrequency;
+            return this;
+        }
+
+        public Builder monitorFrequency(int monitorFrequency) {
+            this.monitorFrequency = monitorFrequency;
+            return this;
+        }
+
+        public DataManagerSyncTrainingListener build() {
+            return new DataManagerSyncTrainingListener(this);
+        }
+
+    }
+}

--- a/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/util/DataManagerSyncTrainingListener.java
+++ b/rl4j/rl4j-core/src/main/java/org/deeplearning4j/rl4j/util/DataManagerSyncTrainingListener.java
@@ -5,6 +5,10 @@ import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingEpochEndEvent;
 import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingEvent;
 import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingListener;
 
+/**
+ * DataManagerSyncTrainingListener can be added to the listeners of SyncLearning so that the
+ * training process can be fed to the DataManager
+ */
 @Slf4j
 public class DataManagerSyncTrainingListener implements SyncTrainingListener {
     private final IDataManager dataManager;
@@ -25,15 +29,14 @@ public class DataManagerSyncTrainingListener implements SyncTrainingListener {
     }
 
     @Override
-    public void onTrainingStart(SyncTrainingEvent event) {
+    public ListenerResponse onTrainingStart(SyncTrainingEvent event) {
         try {
             dataManager.writeInfo(event.getLearning());
         } catch (Exception e) {
             log.error("Training failed.", e);
-            e.printStackTrace();
-
-            event.setCanContinue(false);
+            return ListenerResponse.STOP;
         }
+        return ListenerResponse.CONTINUE;
     }
 
     @Override
@@ -42,7 +45,7 @@ public class DataManagerSyncTrainingListener implements SyncTrainingListener {
     }
 
     @Override
-    public void onEpochStart(SyncTrainingEvent event) {
+    public ListenerResponse onEpochStart(SyncTrainingEvent event) {
         int stepCounter = event.getLearning().getStepCounter();
 
         if (stepCounter - lastMonitor >= monitorFrequency
@@ -53,10 +56,12 @@ public class DataManagerSyncTrainingListener implements SyncTrainingListener {
             event.getLearning().getHistoryProcessor().startMonitor(dataManager.getVideoDir() + "/video-" + event.getLearning().getEpochCounter() + "-"
                     + stepCounter + ".mp4", shape);
         }
+
+        return ListenerResponse.CONTINUE;
     }
 
     @Override
-    public void onEpochEnd(SyncTrainingEpochEndEvent event) {
+    public ListenerResponse onEpochEnd(SyncTrainingEpochEndEvent event) {
         try {
             int stepCounter = event.getLearning().getStepCounter();
             if (stepCounter - lastSave >= saveFrequency) {
@@ -68,10 +73,10 @@ public class DataManagerSyncTrainingListener implements SyncTrainingListener {
             dataManager.writeInfo(event.getLearning());
         } catch (Exception e) {
             log.error("Training failed.", e);
-            e.printStackTrace();
-
-            event.setCanContinue(false);
+            return ListenerResponse.STOP;
         }
+
+        return ListenerResponse.CONTINUE;
     }
 
     public static Builder builder(IDataManager dataManager) {
@@ -83,20 +88,36 @@ public class DataManagerSyncTrainingListener implements SyncTrainingListener {
         private int saveFrequency = Constants.MODEL_SAVE_FREQ;
         private int monitorFrequency = Constants.MONITOR_FREQ;
 
+        /**
+         * Create a Builder with the given DataManager
+         * @param dataManager
+         */
         public Builder(IDataManager dataManager) {
             this.dataManager = dataManager;
         }
 
+        /**
+         * A number that represent the number of steps since the last call to DataManager.save() before can it be called again.
+         * @param saveFrequency (Default: 100000)
+         */
         public Builder saveFrequency(int saveFrequency) {
             this.saveFrequency = saveFrequency;
             return this;
         }
 
+        /**
+         * A number that represent the number of steps since the last call to HistoryProcessor.startMonitor() before can it be called again.
+         * @param monitorFrequency (Default: 10000)
+         */
         public Builder monitorFrequency(int monitorFrequency) {
             this.monitorFrequency = monitorFrequency;
             return this;
         }
 
+        /**
+         * Creates a DataManagerSyncTrainingListener with the configured parameters
+         * @return An instance of DataManagerSyncTrainingListener
+         */
         public DataManagerSyncTrainingListener build() {
             return new DataManagerSyncTrainingListener(this);
         }

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/SyncLearningTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/SyncLearningTest.java
@@ -15,31 +15,6 @@ import static org.junit.Assert.assertEquals;
 
 public class SyncLearningTest {
 
-    // Test to help refac -- will be removed
-    @Test
-    public void refac_checkDataManagerCallsRemainTheSame() {
-        // Arrange
-        QLearning.QLConfiguration lconfig = QLearning.QLConfiguration.builder().maxStep(10).build();
-        MockDataManager dataManager = new MockDataManager(false);
-        MockSyncLearning sut = new MockSyncLearning(lconfig, dataManager);
-
-        // Act
-        sut.train();
-
-        assertEquals(10, dataManager.statEntries.size());
-        for(int i = 0; i < 10; ++i) {
-            IDataManager.StatEntry entry = dataManager.statEntries.get(i);
-            assertEquals(i, entry.getEpochCounter());
-            assertEquals(i+1, entry.getStepCounter());
-            assertEquals(1.0, entry.getReward(), 0.0);
-
-        }
-        assertEquals(0, dataManager.isSaveDataCallCount);
-        assertEquals(0, dataManager.getVideoDirCallCount);
-        assertEquals(11, dataManager.writeInfoCallCount);
-        assertEquals(1, dataManager.saveCallCount);
-    }
-
     @Test
     public void when_training_expect_listenersToBeCalled() {
         // Arrange

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearningDiscreteTest.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/qlearning/QLearningDiscreteTest.java
@@ -1,0 +1,65 @@
+package org.deeplearning4j.rl4j.learning.sync.qlearning;
+
+import org.deeplearning4j.rl4j.learning.IHistoryProcessor;
+import org.deeplearning4j.rl4j.learning.sync.qlearning.discrete.QLearningDiscrete;
+import org.deeplearning4j.rl4j.learning.sync.support.MockDQN;
+import org.deeplearning4j.rl4j.learning.sync.support.MockMDP;
+import org.deeplearning4j.rl4j.learning.sync.support.MockStatEntry;
+import org.deeplearning4j.rl4j.mdp.MDP;
+import org.deeplearning4j.rl4j.support.MockDataManager;
+import org.deeplearning4j.rl4j.support.MockHistoryProcessor;
+import org.deeplearning4j.rl4j.util.DataManagerSyncTrainingListener;
+import org.deeplearning4j.rl4j.util.IDataManager;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class QLearningDiscreteTest {
+    @Test
+    public void refac_checkDataManagerCallsRemainTheSame() {
+        // Arrange
+        QLearning.QLConfiguration lconfig = QLearning.QLConfiguration.builder()
+                .maxStep(10)
+                .expRepMaxSize(1)
+                .build();
+        MockDataManager dataManager = new MockDataManager(true);
+        MockQLearningDiscrete sut = new MockQLearningDiscrete(10, lconfig, dataManager, 2, 3);
+        IHistoryProcessor.Configuration hpConfig = IHistoryProcessor.Configuration.builder()
+                .build();
+        sut.setHistoryProcessor(new MockHistoryProcessor(hpConfig));
+
+        // Act
+        sut.train();
+
+        assertEquals(10, dataManager.statEntries.size());
+        for(int i = 0; i < 10; ++i) {
+            IDataManager.StatEntry entry = dataManager.statEntries.get(i);
+            assertEquals(i, entry.getEpochCounter());
+            assertEquals(i+1, entry.getStepCounter());
+            assertEquals(1.0, entry.getReward(), 0.0);
+
+        }
+        assertEquals(4, dataManager.isSaveDataCallCount);
+        assertEquals(4, dataManager.getVideoDirCallCount);
+        assertEquals(11, dataManager.writeInfoCallCount);
+        assertEquals(5, dataManager.saveCallCount);
+    }
+
+    public static class MockQLearningDiscrete extends QLearningDiscrete {
+
+        public MockQLearningDiscrete(int maxSteps, QLConfiguration conf,
+                                IDataManager dataManager, int saveFrequency, int monitorFrequency) {
+            super(new MockMDP(maxSteps), new MockDQN(), conf, 2);
+            addListener(DataManagerSyncTrainingListener.builder(dataManager)
+                    .saveFrequency(saveFrequency)
+                    .monitorFrequency(monitorFrequency)
+                    .build());
+        }
+
+        @Override
+        protected IDataManager.StatEntry trainEpoch() {
+            setStepCounter(getStepCounter() + 1);
+            return new MockStatEntry(getEpochCounter(), getStepCounter(), 1.0);
+        }
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockDQN.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockDQN.java
@@ -1,0 +1,92 @@
+package org.deeplearning4j.rl4j.learning.sync.support;
+
+import org.deeplearning4j.nn.api.NeuralNetwork;
+import org.deeplearning4j.nn.gradient.Gradient;
+import org.deeplearning4j.rl4j.network.NeuralNet;
+import org.deeplearning4j.rl4j.network.dqn.IDQN;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class MockDQN implements IDQN {
+    @Override
+    public NeuralNetwork[] getNeuralNetworks() {
+        return new NeuralNetwork[0];
+    }
+
+    @Override
+    public boolean isRecurrent() {
+        return false;
+    }
+
+    @Override
+    public void reset() {
+
+    }
+
+    @Override
+    public void fit(INDArray input, INDArray labels) {
+
+    }
+
+    @Override
+    public void fit(INDArray input, INDArray[] labels) {
+
+    }
+
+    @Override
+    public INDArray output(INDArray batch) {
+        return null;
+    }
+
+    @Override
+    public INDArray[] outputAll(INDArray batch) {
+        return new INDArray[0];
+    }
+
+    @Override
+    public IDQN clone() {
+        return null;
+    }
+
+    @Override
+    public void copy(NeuralNet from) {
+
+    }
+
+    @Override
+    public void copy(IDQN from) {
+
+    }
+
+    @Override
+    public Gradient[] gradient(INDArray input, INDArray label) {
+        return new Gradient[0];
+    }
+
+    @Override
+    public Gradient[] gradient(INDArray input, INDArray[] label) {
+        return new Gradient[0];
+    }
+
+    @Override
+    public void applyGradient(Gradient[] gradient, int batchSize) {
+
+    }
+
+    @Override
+    public double getLatestScore() {
+        return 0;
+    }
+
+    @Override
+    public void save(OutputStream os) throws IOException {
+
+    }
+
+    @Override
+    public void save(String filename) throws IOException {
+
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockMDP.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockMDP.java
@@ -1,0 +1,79 @@
+package org.deeplearning4j.rl4j.learning.sync.support;
+
+import org.deeplearning4j.gym.StepReply;
+import org.deeplearning4j.rl4j.mdp.MDP;
+import org.deeplearning4j.rl4j.space.DiscreteSpace;
+import org.deeplearning4j.rl4j.space.ObservationSpace;
+import org.nd4j.linalg.api.ndarray.INDArray;
+
+public class MockMDP implements MDP<Object, Integer, DiscreteSpace> {
+
+    private final int maxSteps;
+    private final DiscreteSpace actionSpace = new DiscreteSpace(1);
+    private final MockObservationSpace observationSpace = new MockObservationSpace();
+
+    private int currentStep = 0;
+
+    public MockMDP(int maxSteps) {
+
+        this.maxSteps = maxSteps;
+    }
+
+    @Override
+    public ObservationSpace<Object> getObservationSpace() {
+        return observationSpace;
+    }
+
+    @Override
+    public DiscreteSpace getActionSpace() {
+        return actionSpace;
+    }
+
+    @Override
+    public Object reset() {
+        return null;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public StepReply<Object> step(Integer integer) {
+        return new StepReply<Object>(null, 1.0, isDone(), null);
+    }
+
+    @Override
+    public boolean isDone() {
+        return currentStep >= maxSteps;
+    }
+
+    @Override
+    public MDP<Object, Integer, DiscreteSpace> newInstance() {
+        return null;
+    }
+
+    private static class MockObservationSpace implements ObservationSpace {
+
+        @Override
+        public String getName() {
+            return null;
+        }
+
+        @Override
+        public int[] getShape() {
+            return new int[0];
+        }
+
+        @Override
+        public INDArray getLow() {
+            return null;
+        }
+
+        @Override
+        public INDArray getHigh() {
+            return null;
+        }
+    }
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockStatEntry.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockStatEntry.java
@@ -1,0 +1,13 @@
+package org.deeplearning4j.rl4j.learning.sync.support;
+
+import lombok.AllArgsConstructor;
+import lombok.Value;
+import org.deeplearning4j.rl4j.util.IDataManager;
+
+@AllArgsConstructor
+@Value
+public class MockStatEntry implements IDataManager.StatEntry {
+    int epochCounter;
+    int stepCounter;
+    double reward;
+}

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockSyncTrainingListener.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockSyncTrainingListener.java
@@ -16,9 +16,9 @@ public class MockSyncTrainingListener implements SyncTrainingListener {
     public int nbStepsEpochEndCanContinue = Integer.MAX_VALUE;
 
     @Override
-    public void onTrainingStart(SyncTrainingEvent event) {
+    public ListenerResponse onTrainingStart(SyncTrainingEvent event) {
         ++onTrainingStartCallCount;
-        event.setCanContinue(trainingStartCanContinue);
+        return trainingStartCanContinue ? ListenerResponse.CONTINUE : ListenerResponse.STOP;
     }
 
     @Override
@@ -27,18 +27,20 @@ public class MockSyncTrainingListener implements SyncTrainingListener {
     }
 
     @Override
-    public void onEpochStart(SyncTrainingEvent event) {
+    public ListenerResponse onEpochStart(SyncTrainingEvent event) {
         ++onEpochStartCallCount;
         if(onEpochStartCallCount >= nbStepsEpochStartCanContinue) {
-            event.setCanContinue(false);
+            return ListenerResponse.STOP;
         }
+        return ListenerResponse.CONTINUE;
     }
 
     @Override
-    public void onEpochEnd(SyncTrainingEpochEndEvent event) {
+    public ListenerResponse onEpochEnd(SyncTrainingEpochEndEvent event) {
         ++onEpochEndStartCallCount;
         if(onEpochEndStartCallCount >= nbStepsEpochEndCanContinue) {
-            event.setCanContinue(false);
+            return ListenerResponse.STOP;
         }
+        return ListenerResponse.CONTINUE;
     }
 }

--- a/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockSyncTrainingListener.java
+++ b/rl4j/rl4j-core/src/test/java/org/deeplearning4j/rl4j/learning/sync/support/MockSyncTrainingListener.java
@@ -1,0 +1,44 @@
+package org.deeplearning4j.rl4j.learning.sync.support;
+
+import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingEpochEndEvent;
+import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingEvent;
+import org.deeplearning4j.rl4j.learning.sync.listener.SyncTrainingListener;
+
+public class MockSyncTrainingListener implements SyncTrainingListener {
+
+    public int onTrainingStartCallCount = 0;
+    public int onTrainingEndCallCount = 0;
+    public int onEpochStartCallCount = 0;
+    public int onEpochEndStartCallCount = 0;
+
+    public boolean trainingStartCanContinue = true;
+    public int nbStepsEpochStartCanContinue = Integer.MAX_VALUE;
+    public int nbStepsEpochEndCanContinue = Integer.MAX_VALUE;
+
+    @Override
+    public void onTrainingStart(SyncTrainingEvent event) {
+        ++onTrainingStartCallCount;
+        event.setCanContinue(trainingStartCanContinue);
+    }
+
+    @Override
+    public void onTrainingEnd() {
+        ++onTrainingEndCallCount;
+    }
+
+    @Override
+    public void onEpochStart(SyncTrainingEvent event) {
+        ++onEpochStartCallCount;
+        if(onEpochStartCallCount >= nbStepsEpochStartCanContinue) {
+            event.setCanContinue(false);
+        }
+    }
+
+    @Override
+    public void onEpochEnd(SyncTrainingEpochEndEvent event) {
+        ++onEpochEndStartCallCount;
+        if(onEpochEndStartCallCount >= nbStepsEpochEndCanContinue) {
+            event.setCanContinue(false);
+        }
+    }
+}


### PR DESCRIPTION
Signed-off-by: Alexandre Boulanger <aboulang2002@yahoo.com>

## What changes were proposed in this pull request?

The goal of this PR is to remove IDataManager from SyncLearning. I added a listener pattern to SyncLearning, and a listener class (DataManagerSyncTrainingListener) that will make the calls to DataManager that SyncLearning used to do.

I removed the try/catch from SyncLearning.train(). Listeners should be well-behaved and not throw. If a listener need to stop the training (because of an IOException for example), it can with SyncTrainingEvent.setCanContinue(false).

Since SyncLearning doesn't use IDataManager anymore, I moved it to ASyncLearning (where a similar refac will be done in an upcoming PR).

I did not add javadoc to IDataManager and IAsyncGlobal.
In the case of IDataManager/DataManager, it may be worthwhile to refac it. For example, isSaveData() will soon not be necessary anymore. Also, it seems strange to me that a DataManager would return the path where to save the videos which are then saved by a HistoryProcessor. I will write the javadoc when I change this class.
In the case of IAsyncGlobal, I don't understand a few things and I'd like to take the time to read and understand "Hogwild!" before writing the javadoc.

Summary of changes:
 - Moved up IDataManager from Learning to ASyncLearning and removed it from SyncLearning
 - Some code in QLearningDiscrete.postEpoch() has been moved to DataManagerSyncTrainingListener.onEpochEnd()
 - Added listener pattern to SyncLearning along with a listener, DataManagerSyncTrainingListener.
 - Adjusted SyncLearningTest for the new listener
 - Added refac tests to QLearningDiscrete to make sure it remains functionally the same as before.

## How was this patch tested?

Unit tests

## Quick checklist

The following checklist helps ensure your PR is complete:

- [X] Eclipse Contributor Agreement signed, and signed commits - see [IP Requirements](https://deeplearning4j.org/eclipse-contributors) page for details
- [X] Reviewed the [Contributing Guidelines](https://github.com/eclipse/deeplearning4j/blob/master/CONTRIBUTING.md) and followed the steps within.
- [X] Created tests for any significant new code additions.
- [X] Relevant tests for your changes are passing.
