### PR TITLE
Removed unused declarations that seemed to bother ncc

### DIFF
--- a/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests9.cpp
+++ b/libnd4j/tests_cpu/layers_tests/DeclarableOpsTests9.cpp
@@ -615,12 +615,11 @@ TEST_F(DeclarableOpsTests9, concat_test17) {
 
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests9, concat_test18) {
-    std::array<NDArray*, 2000> arrays;
     Context context(1);
     Nd4jLong axis = 0;
 
     // we crate bunch of arrays, filled with specific values
-    for (int e = 0; e < arrays.size(); e++) {
+    for (int e = 0; e < 2000; e++) {
         auto array = NDArrayFactory::create_<float>('c', {1, 300});
         array->assign(e);
         context.setInputArray(e, array, true);
@@ -633,7 +632,7 @@ TEST_F(DeclarableOpsTests9, concat_test18) {
     nd4j::ops::concat op;
     op.execute(&context);
 
-    for (int e = 0; e < arrays.size(); e++) {
+    for (int e = 0; e < 2000; e++) {
         auto row = z.tensorAlongDimension(e, {1});
 
         ASSERT_NEAR((float) e, row->e<float>(0), 1e-5f);
@@ -645,25 +644,24 @@ TEST_F(DeclarableOpsTests9, concat_test18) {
 //////////////////////////////////////////////////////////////////////
 TEST_F(DeclarableOpsTests9, concat_test19) {
 
-    std::array<NDArray*, 10> arrays;
     Context context(1);
     Nd4jLong axis = 0;
 
     // we crate bunch of arrays, filled with specific values
-    for (int e = 0; e < arrays.size(); e++) {
+    for (int e = 0; e < 10; e++) {
         auto array = NDArrayFactory::create_<float>('c', {1, 5, 20});
         array->assign(e);
         context.setInputArray(e, array, true);
     }
 
-    auto z = NDArrayFactory::create<float>('c', {(Nd4jLong) arrays.size(), 5, 20});
+    auto z = NDArrayFactory::create<float>('c', {10, 5, 20});
     context.setOutputArray(0, &z, false);
     context.setIArguments(&axis, 1);
 
     nd4j::ops::concat op;
     op.execute(&context);
 
-    for (int e = 0; e < arrays.size(); e++)
+    for (int e = 0; e < 10; e++)
         ASSERT_NEAR((float) e, z(e, {0}).meanNumber().e<float>(0), 1e-5f);
 }
 


### PR DESCRIPTION
The tests `concat_test18` and `concat_test19`, declared in `DeclarableOpsTests9.cpp` initializes an array that is never used, except to reference its size. It looks like it is a remain of an earlier version of the tests. For some reason yet to be investigated, `ncc`'s optimizer does not like these declarations.

Removing the declarations and replacing the references to `arrays.size()` by a constant makes the test compile and run correctly.