### PR TITLE
Remove old datavec.spark.version tag

### DIFF
--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark-nlp/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.datavec</groupId>
             <artifactId>datavec-spark_2.11</artifactId>
-            <version>${datavec.spark.version}</version>
+            <version>${datavec.version}</version>
         </dependency>
 
         <dependency>

--- a/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/dl4j-spark/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.datavec</groupId>
             <artifactId>datavec-spark_2.11</artifactId>
-            <version>${datavec.spark.version}</version>
+            <version>${datavec.version}</version>
         </dependency>
 
         <dependency>

--- a/deeplearning4j/deeplearning4j-scaleout/spark/pom.xml
+++ b/deeplearning4j/deeplearning4j-scaleout/spark/pom.xml
@@ -36,8 +36,6 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <datavec.spark.version>1.0.0-SNAPSHOT</datavec.spark.version>
-
 
         <scala.macros.version>2.1.0</scala.macros.version>
         <!-- Default scala versions, may be overwritten by build profiles -->

--- a/docs/deeplearning4j-scaleout/templates/intro.md
+++ b/docs/deeplearning4j-scaleout/templates/intro.md
@@ -47,7 +47,7 @@ To use the gradient sharing implementation include the following dependency:
 <dependency>
     <groupId>org.deeplearning4j</groupId>
     <artifactId>dl4j-spark-parameterserver_${scala.binary.version}</artifactId>
-    <version>${dl4j.spark.version}</version>
+    <version>${dl4j.version}</version>
 </dependency>
 ```
 
@@ -57,7 +57,7 @@ If using the parameter averaging implementation (again, the gradient sharing imp
 <dependency>
         <groupId>org.deeplearning4j</groupId>
         <artifactId>dl4j-spark_${scala.binary.version}</artifactId>
-        <version>${dl4j.spark.version}</version>
+        <version>${dl4j.version}</version>
 </dependency>
 ```
 Note that ${scala.binary.version} is a Maven property with the value 2.10 or 2.11 and should match the version of Spark you are using.

--- a/docs/deeplearning4j-scaleout/templates/parameter-server.md
+++ b/docs/deeplearning4j-scaleout/templates/parameter-server.md
@@ -58,7 +58,7 @@ Here's the template for the only required dependency:
 <dependency>
     <groupId>org.deeplearning4j</groupId>
     <artifactId>dl4j-spark-parameterserver_${scala.binary.version}</artifactId>
-    <version>${dl4j.spark.version}</version>
+    <version>${dl4j.version}</version>
 </dependency>
 ```
 
@@ -68,7 +68,7 @@ For example:
 <dependency>
     <groupId>org.deeplearning4j</groupId>
     <artifactId>dl4j-spark-parameterserver_2.11</artifactId>
-    <version>0.9.1_spark_2</version>
+    <version>${dl4j.version}</version>
 </dependency>
 ```
 

--- a/docs/deeplearning4j/templates/config-snapshots.md
+++ b/docs/deeplearning4j/templates/config-snapshots.md
@@ -59,15 +59,6 @@ To version:
 <nd4j.version>1.0.0-SNAPSHOT</nd4j.version>
 ```
 
-For Spark dependencies, change as follows:
-```
-<dl4j.spark.version>1.0.0-beta2_spark_2</dl4j.spark.version>
-```
-to
-```
-<dl4j.spark.version>1.0.0_spark_2-SNAPSHOT</dl4j.spark.version>
-```
-
 **Sample pom.xml using Snapshots**
 
 A sample pom.xml is provided here: [sample pom.xml using snapshots](https://gist.github.com/AlexDBlack/28b0c9a72bce562c8782be326a6e2aaa)


### PR DESCRIPTION
Fixes: https://github.com/eclipse/deeplearning4j/issues/8230